### PR TITLE
Bugfix: add project name to pyproject.toml

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,3 +1,6 @@
+[project]
+name = "stackit-core"
+
 [tool.poetry]
 name = "stackit-core"
 version = "v0.1.0"


### PR DESCRIPTION
Since core is not generated via mustache this needs to be udpated manually.