### PR TITLE
fix: remove python 3.8 run in ci pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,10 +5,19 @@ on: [pull_request, workflow_dispatch]
 jobs:
   main:
     name: CI
+    continue-on-error: ${{ matrix.optional }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        optional: [false]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.8"
+            optional: true
+          - os: macos-latest
+            python-version: "3.8"
+            optional: true
     runs-on: ${{ matrix.os }}
     steps:      
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,19 +5,10 @@ on: [pull_request, workflow_dispatch]
 jobs:
   main:
     name: CI
-    continue-on-error: ${{ matrix.optional }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        optional: [false]
-        include:
-          - os: ubuntu-latest
-            python-version: "3.8"
-            optional: true
-          - os: macos-latest
-            python-version: "3.8"
-            optional: true
     runs-on: ${{ matrix.os }}
     steps:      
       - name: Checkout


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to [#1234](https://github.com/stackitcloud/stackit-sdk-generator/pull/169)

## Checklist

- [x] Issue was linked above
- [ ] **No generated code was adjusted manually** (check [comments in file header](https://github.com/stackitcloud/stackit-sdk-python/blob/main/services/dns/src/stackit/dns/api_client.py#L10-L12))
- [ ] Changelogs and versioning
    - [ ] Changelog in root directory was adjusted (see [here](https://github.com/stackitcloud/stackit-sdk-python/blob/608176ab8cdfa60a3cfb09da49de0b1aba5fea84/CHANGELOG.md))
    - [ ] Changelog of the service(s) was adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-sdk-python/blob/608176ab8cdfa60a3cfb09da49de0b1aba5fea84/services/dns/CHANGELOG.md))
    - [ ] `pyproject.toml` of the service(s) was adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-sdk-python/blob/608176ab8cdfa60a3cfb09da49de0b1aba5fea84/services/dns/pyproject.toml))
- [ ] Examples were added / adjusted (see `examples/` directory)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
