### PR TITLE
feat(sdk): add version linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ lint-services:
 	flake8 --toml-config core/pyproject.toml --black-config core/pyproject.toml examples; 
 	# lint services
 	@for f in $(shell ls ${SERVICES_DIR}); do set -e; cd ${SERVICES_DIR}/$${f};poetry install --no-root --only dev; flake8 .; cd ../..; done
+	# lint versions
+	@./scripts/lint-versions.sh
 
 test:
 	echo "Testing service ${service}"

--- a/scripts/lint-versions.sh
+++ b/scripts/lint-versions.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Immediate exit on failure
+set -e
+
+echo ">> Linting SDK module versions..."
+
+# Check all pyproject.toml files 
+for file in $(find . -print | sed 's|^./||' | grep -E "(^services/[^/]+/pyproject.toml$|^core/pyproject.toml$)"); do
+    # Extract the current version 
+    dirpath=$(dirname "$file")
+    version=$(scripts/helper.sh "$dirpath")
+
+    # skip iaasalpha
+    case "$dirpath" in
+        "services/iaasalpha")
+            continue
+            ;;
+    esac
+
+    # special handling for CDN (is in v2 by accident)
+    if [[ "$dirpath" == "services/cdn" ]]; then
+        if [[ ! "$version" =~ ^v[0-2]\.[0-9]+\.[0-9]+$ ]]; then
+            echo ">> $dirpath"
+            echo "The version '$version' is invalid."
+            exit 1
+        fi
+        continue
+    fi
+
+    # verify version
+    if [[ ! "$version" =~ ^v[0-1]\.[0-9]+\.[0-9]+$ ]]; then
+        echo ">> $dirpath"
+        echo "The version '$version' is invalid."
+        exit 1
+    fi
+done


### PR DESCRIPTION
## Checklist

- [ ] Issue was linked above
- [ ] **No generated code was adjusted manually** (check [comments in file header](https://github.com/stackitcloud/stackit-sdk-python/blob/main/services/dns/src/stackit/dns/api_client.py#L10-L12))
- [ ] Changelogs and versioning
    - [ ] Changelog in root directory was adjusted (see [here](https://github.com/stackitcloud/stackit-sdk-python/blob/608176ab8cdfa60a3cfb09da49de0b1aba5fea84/CHANGELOG.md))
    - [ ] Changelog of the service(s) was adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-sdk-python/blob/608176ab8cdfa60a3cfb09da49de0b1aba5fea84/services/dns/CHANGELOG.md))
    - [ ] `pyproject.toml` of the service(s) was adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-sdk-python/blob/608176ab8cdfa60a3cfb09da49de0b1aba5fea84/services/dns/pyproject.toml))
- [ ] Examples were added / adjusted (see `examples/` directory)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
