### PR TITLE
fix(linter): set prefix "v" in version as optional

### DIFF
--- a/scripts/lint-versions.sh
+++ b/scripts/lint-versions.sh
@@ -20,7 +20,7 @@ for file in $(find . -print | sed 's|^./||' | grep -E "(^services/[^/]+/pyprojec
 
     # special handling for CDN (is in v2 by accident)
     if [[ "$dirpath" == "services/cdn" ]]; then
-        if [[ ! "$version" =~ ^v[0-2]\.[0-9]+\.[0-9]+$ ]]; then
+        if [[ ! "$version" =~ ^v?[0-2]\.[0-9]+\.[0-9]+$ ]]; then
             echo ">> $dirpath"
             echo "The version '$version' is invalid."
             exit 1
@@ -29,7 +29,7 @@ for file in $(find . -print | sed 's|^./||' | grep -E "(^services/[^/]+/pyprojec
     fi
 
     # verify version
-    if [[ ! "$version" =~ ^v[0-1]\.[0-9]+\.[0-9]+$ ]]; then
+    if [[ ! "$version" =~ ^v?[0-1]\.[0-9]+\.[0-9]+$ ]]; then
         echo ">> $dirpath"
         echo "The version '$version' is invalid."
         exit 1


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITSDK-308

## Checklist

- [x] Issue was linked above
- [ ] **No generated code was adjusted manually** (check [comments in file header](https://github.com/stackitcloud/stackit-sdk-python/blob/main/services/dns/src/stackit/dns/api_client.py#L10-L12))
- [ ] Changelogs and versioning
    - [ ] Changelog in root directory was adjusted (see [here](https://github.com/stackitcloud/stackit-sdk-python/blob/608176ab8cdfa60a3cfb09da49de0b1aba5fea84/CHANGELOG.md))
    - [ ] Changelog of the service(s) was adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-sdk-python/blob/608176ab8cdfa60a3cfb09da49de0b1aba5fea84/services/dns/CHANGELOG.md))
    - [ ] `pyproject.toml` of the service(s) was adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-sdk-python/blob/608176ab8cdfa60a3cfb09da49de0b1aba5fea84/services/dns/pyproject.toml))
- [ ] Examples were added / adjusted (see `examples/` directory)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
