### PR TITLE
fix(ci-cd): don't run labeler on PRs from forks

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: [opened, synchronize]
   workflow_dispatch:
+  schedule:
+    # run every full hour (to still label PRs from forks)
+    - cron: '0 * * * *'
 
 jobs:
   labeler:
@@ -10,6 +13,8 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+    # don't run on PRs from forks (token has no write permissions)
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     name: "Labeler"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
instead use a cron schedule to label PRs from forks

