### PR TITLE
chore(ci): parallelize build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,8 +19,8 @@ jobs:
           version: "0.10.4"
           python-version: ${{ matrix.python-version }}
       - name: Install
-        run: make install-dev
+        run: make install-dev -j
       - name: Lint        
-        run: make lint-services
+        run: make lint-services -j
       - name: Test
-        run: make test-services
+        run: make test-services -j

--- a/.github/workflows/dependency-checker.yaml
+++ b/.github/workflows/dependency-checker.yaml
@@ -29,7 +29,7 @@ jobs:
         
             pr_name=$(echo "Dependency Updates")
 
-            make update-dependencies          
+            make update-dependencies -j
             branch_name="dependency-updater-${{ github.run_id }}"
             git checkout -b "$branch_name"
 

--- a/Makefile
+++ b/Makefile
@@ -1,43 +1,72 @@
 SERVICES_DIR := services
+SERVICES := $(shell ls $(SERVICES_DIR))
 
-install:
-	# install core
+INSTALL_TARGETS := $(addprefix install-,$(SERVICES))
+INSTALL_DEV_TARGETS := $(addprefix install-dev-,$(SERVICES))
+TEST_TARGETS := $(addprefix test-,$(SERVICES))
+LINT_TARGETS := $(addprefix lint-,$(SERVICES))
+UPDATE_TARGETS := $(addprefix update-dependencies-,$(SERVICES))
+
+.PHONY: install install-core $(INSTALL_TARGETS)
+install: install-core $(INSTALL_TARGETS)
+
+install-core:
 	uv sync --no-dev --directory core/
-	# install services
-	@for f in $(shell ls ${SERVICES_DIR}); do uv sync --no-dev --directory ${SERVICES_DIR}/$${f}; done
 
-install-dev:	
-	# install services
-	@for f in $(shell ls ${SERVICES_DIR}); do set -e;uv sync --frozen --directory ${SERVICES_DIR}/$${f}; done
+$(INSTALL_TARGETS): install-%:
+	# install service $*
+	uv sync --no-dev --directory $(SERVICES_DIR)/$*
+
+.PHONY: install-dev $(INSTALL_DEV_TARGETS)
+install-dev: $(INSTALL_DEV_TARGETS)
 	# install core. This needs to be done last or it will get overriden by the dependency installation of the services
 	uv sync --frozen --directory core
 
-test-services:
-	# test core
+$(INSTALL_DEV_TARGETS): install-dev-%:
+	# install service $*
+	uv sync --frozen --directory $(SERVICES_DIR)/$*
+
+.PHONY: test-services test-core $(TEST_TARGETS)
+test-services: test-core $(TEST_TARGETS)
+
+test-core:
 	cd core && uv run pytest
-	# test services
-	@for f in $(shell ls ${SERVICES_DIR}); do  set -e; cd ${SERVICES_DIR}/$${f}; sh -c ' uv run pytest || ([ $$? = 5 ] && exit 0 || exit $$?)'; cd ../..; done
 
-lint-services:
-	# lint core
+$(TEST_TARGETS): test-%:
+	# test service $*
+	cd $(SERVICES_DIR)/$* && sh -c 'uv run pytest || ([ $$? = 5 ] && exit 0 || exit $$?)'
+
+.PHONY: lint-services lint-core lint-examples lint-versions $(LINT_TARGETS)
+lint-services: lint-core lint-examples $(LINT_TARGETS) lint-versions
+
+lint-core:
 	cd core && uv run flake8 .
-	# lint examples. Use configuration from core
-	cd core && uv run flake8 --toml-config pyproject.toml --black-config pyproject.toml ../examples;
-	# lint services
-	@for f in $(shell ls ${SERVICES_DIR}); do set -e; cd ${SERVICES_DIR}/$${f};uv run flake8 .; cd ../..; done
-	# lint versions
-	@./scripts/lint-versions.sh
 
+lint-examples:
+	# lint examples. Use configuration from core
+	cd core && uv run flake8 --toml-config pyproject.toml --black-config pyproject.toml ../examples
+
+$(LINT_TARGETS): lint-%:
+	# lint service $*
+	cd $(SERVICES_DIR)/$* && uv run flake8 .
+
+lint-versions:
+	# lint versions
+	./scripts/lint-versions.sh
+
+# Old parameterized targets for single service, aliased to pattern rules
 test:
-	echo "Testing service ${service}"
-	cd ${SERVICES_DIR}/${service}; sh -c ' uv run pytest || ([ $$? = 5 ] && exit 0 || exit $$?)'; cd ../..;
+	$(MAKE) test-$(service)
 
 lint:
-	echo "Linting service ${service}"
-	cd ${SERVICES_DIR}/${service};uv run flake8 .; cd ../..;
+	$(MAKE) lint-$(service)
 
-update-dependencies:
-	# lock core
+.PHONY: update-dependencies update-dependencies-core $(UPDATE_TARGETS)
+update-dependencies: update-dependencies-core $(UPDATE_TARGETS)
+
+update-dependencies-core:
 	cd core && uv lock
-	# lock services
-	@for f in $(shell ls ${SERVICES_DIR}); do set -e; cd ${SERVICES_DIR}/$${f};uv lock; cd ../..; done
+
+$(UPDATE_TARGETS): update-dependencies-%:
+	# lock service $*
+	cd $(SERVICES_DIR)/$* && uv lock


### PR DESCRIPTION
- some targets in makefile first did sth. to core and then to each service
- the work on the services can be done in parallel
- create a target for core, use pattern rules to create targets for each service
- change workflows to use makes `-j` for parallelism

## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [ ] **No generated code was adjusted manually** (check [comments in file header](https://github.com/stackitcloud/stackit-sdk-python/blob/main/services/dns/src/stackit/dns/api_client.py#L10-L12))
- [ ] Changelogs and versioning
    - [ ] Changelog in root directory was adjusted (see [here](https://github.com/stackitcloud/stackit-sdk-python/blob/608176ab8cdfa60a3cfb09da49de0b1aba5fea84/CHANGELOG.md))
    - [ ] Changelog of the service(s) was adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-sdk-python/blob/608176ab8cdfa60a3cfb09da49de0b1aba5fea84/services/dns/CHANGELOG.md))
    - [ ] `pyproject.toml` of the service(s) was adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-sdk-python/blob/608176ab8cdfa60a3cfb09da49de0b1aba5fea84/services/dns/pyproject.toml))
- [ ] Examples were added / adjusted (see `examples/` directory)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
